### PR TITLE
chore: Disable React Strictmode

### DIFF
--- a/client/polyfills.ts
+++ b/client/polyfills.ts
@@ -1,1 +1,0 @@
-import 'core-js/features/object/from-entries';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -45,7 +45,7 @@ export default withPlugins(plugins, {
   // swcMinify: true,
 
   poweredByHeader: false,
-  reactStrictMode: true,
+  reactStrictMode: false,
   compress: true,
 
   /**

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@typescript-eslint/parser": "^5.32.0",
     "@vercel/build-utils": "^5.2.0",
     "@vercel/client": "^12.1.10",
-    "apollo": "^2.11.1",
+    "apollo": "^2.34.0",
     "axios": "^0.27.2",
     "babel-loader": "^8.2.5",
     "circular-dependency-plugin": "^5.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4516,7 +4516,7 @@ apollo-utilities@1.3.4, apollo-utilities@^1.3.0, apollo-utilities@^1.3.4:
     ts-invariant "^0.4.0"
     tslib "^1.10.0"
 
-apollo@^2.11.1:
+apollo@^2.34.0:
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/apollo/-/apollo-2.34.0.tgz#ffd5578e24f4f1840fc56ac047c4080c4104fdc3"
   integrity sha512-gDH+WBN+b6TA/tIrIuAyO6Df4tsHwAA/t3NZqUitOM0gKo/nXNOUZzskAFTjErL6fgp5+kYIP3rZ+bIleqXAKg==


### PR DESCRIPTION
**_What will change?_**

- Disabled React strictmode as it conflicts with Apollo's clientside hooks
- Removed an unused polyfills file
- Updated the apollo client library
