### PR TITLE
chore: [PLATO-70] template repository configuration (eslint, prettier, etc)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,8 +8,7 @@
     "plugin:react/recommended",
     "standard-with-typescript",
     "prettier",
-    "airbnb",
-    "prettier/react"
+    "airbnb"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -20,18 +19,32 @@
     "sourceType": "module",
     "project": "./tsconfig.json"
   },
-  "plugins": ["react", "@typescript-eslint", "react-hooks", "prettier"],
+  "plugins": [
+    "react",
+    "@typescript-eslint",
+    "react-hooks",
+    "prettier",
+    "simple-import-sort",
+    "import"
+  ],
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/strict-boolean-expressions": "off",
-    "@typescript-eslint/restrict-template-expressions": ["error", { "allowNullish": true }],
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      { "allowNullish": true }
+    ],
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/prefer-optional-chain": "warn",
     "@typescript-eslint/no-var-requires": "error",
-    "import/no-duplicates": "error",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+    "import/no-duplicates": "error",
+    "import/no-unresolved": "error",
+    "import/newline-after-import": "error"
   },
   "overrides": [
     {
@@ -47,6 +60,9 @@
       "version": "detect"
     },
     "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true
+      },
       "alias": {
         "map": [
           ["@pages", "./pages"],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,4 @@
 {
   "singleQuote": true,
-  "trailingComma": "all",
-  "printWidth": 100,
-  "bracketSameLine": true,
-  "jsxSingleQuote": true
+  "trailingComma": "all"
 }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-simple-import-sort": "^8.0.0",
     "eslint-plugin-standard": "^5.0.0",
     "postcss": "^8.4.14",
     "prettier": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7140,6 +7140,11 @@ eslint-plugin-react@^7.31.8:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
+eslint-plugin-simple-import-sort@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-8.0.0.tgz#9d9a2372b0606e999ea841b10458a370a6ccc160"
+  integrity sha512-bXgJQ+lqhtQBCuWY/FUWdB27j4+lqcvXv5rUARkzbeWLwea+S5eBZEQrhnO+WgX3ZoJHVj0cn943iyXwByHHQw==
+
 eslint-plugin-standard@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz#c43f6925d669f177db46f095ea30be95476b1ee4"


### PR DESCRIPTION
**_What will change?_**

https://contentful.atlassian.net/browse/GROWTH1-70

This PR configures some eslint rules, prettier rules and fixes some eslint issues.

Some rules are set to `off` or `warn` and they can be changed depending on what we need. Also rules can be added or taken out depending on what we agree on. 

`Read me` was also updated with the correct `example env` and start scripts. 

`package json` was also updated with eslint packages and script

Currently running `yarn lint` returns some warnings and errors, this can be fixed depending on what we decide concerning the rule - To enforce or turn off or warn? 

![Screenshot 2022-09-16 at 17 09 42](https://user-images.githubusercontent.com/29452947/190671692-b1a360e6-87f8-4f1c-be56-eb247b308764.png)

**_Question_**

Would we be running linters against staged file? is that something we need to add?
