### PR TITLE
chore: [PLATO-179] add vault secrets yml

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -1,0 +1,5 @@
+version: 1
+services:
+  github-action:
+    policies:
+    - dependabot


### PR DESCRIPTION
Following the latest Contentful's GitHub auto-merge [repository](https://github.com/contentful/github-auto-merge), we add the vault secrets yml file to enable the pull of the vault token.