### PR TITLE
fix: [] locale public path

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,7 +1,10 @@
+const path = require('path')
+
 module.exports = {
   i18n: {
     defaultLocale: 'en-US',
     locales: ['en-US', 'de-DE'],
     localeDetection: false,
+    localePath: path.resolve('./public/locales'),
   },
 };


### PR DESCRIPTION
It fixes the public path resolution for the locales on Vercel, thanks to https://github.com/i18next/next-i18next/issues/462#issuecomment-832793454 

## How to QA

From the branch preview URL, you should see the translation in the footer.

Before
<img width="731" alt="Screenshot 2022-10-28 at 11 59 38" src="https://user-images.githubusercontent.com/103024358/198561071-417c7f38-c69f-494a-b503-6159dd24ba2d.png">

After
<img width="804" alt="Screenshot 2022-10-28 at 12 08 28" src="https://user-images.githubusercontent.com/103024358/198562720-774a5038-432a-41bf-a38f-2059115d63be.png">
