### PR TITLE
chore: [] disabled robots indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+# As soon as you are ready to go public, change the `Disallow: /` to `Allow: /`
+User-agent: *
+Disallow: /


### PR DESCRIPTION
It adds the `robots.txt` file to the `./public` folder to disable the search engine crawlers and as a result disables the indexing of the app.