### PR TITLE
chore: [PLATO-225] add deploy buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ We offer integrations with Vercel and Netlify to speed up the process (by settin
 | Vercel  | Netlify  |
 |---|---|
 | [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcontentful%2Ftemplate-marketing-webapp-nextjs&env=NEXT_PUBLIC_CONFIG_CONTENTFUL_SPACE_ID,NEXT_PUBLIC_CONFIG_CONTENTFUL_DELIVERY_API_TOKEN,NEXT_PUBLIC_CONFIG_CONTENTFUL_PREVIEW_API_TOKEN&envDescription=API%20Keys%20needed%20for%20the%20application&envLink=https%3A%2F%2Fgithub.com%2Fcontentful%2Ftemplate-marketing-webapp-nextjs%23environment-variables) | [![Deploy to Netlify Button](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https%3A%2F%2Fgithub.com%2Fcontentful%2Ftemplate-marketing-webapp-nextjs#NEXT_PUBLIC_CONFIG_CONTENTFUL_SPACE_ID=&NEXT_PUBLIC_CONFIG_CONTENTFUL_DELIVERY_API_TOKEN=&NEXT_PUBLIC_CONFIG_CONTENTFUL_PREVIEW_API_TOKEN=) |
+| [Environment variables docs](https://vercel.com/docs/concepts/projects/environment-variables) | [Environment variables docs](https://docs.netlify.com/environment-variables/overview/) |
 
 Make sure to add the necessary [environment variables values](./README.md#environment-variables) to the hosting provider environment variables.
 


### PR DESCRIPTION
## Purpose of PR

Because we are not using the install & deploy scripts anymore, we want to offer an easy way to deploy the Starter Template to some hosting providers. 

We include Vercel and Netlify deploy buttons, with guidance to update the env. variables and the content preview.

## TODO

- [x] Add a section regarding how to update the preview URL after deployment -> with Vercel, we can have redirect after successful deployment, we could redirect to the appropriate README section
- [ ] Test the whole deployment flow of both options