### PR TITLE
fix: [PLATO-376] Fix Microsoft Edge hydration issue

### DIFF
--- a/src/components/features/language-selector/LanguageSelector.tsx
+++ b/src/components/features/language-selector/LanguageSelector.tsx
@@ -20,7 +20,7 @@ export const LanguageSelector = () => {
   const classes = useStyles();
   const router = useRouter();
 
-  const languageNames = new Intl.DisplayNames([locale || 'en'], {
+  const languageNames = new Intl.DisplayNames([], {
     type: 'language',
   });
 


### PR DESCRIPTION
We were seeing some errors for Microsoft Edge where the client was falling back to client side rendering due to a mismatch with the SSR code.

This is due to a difference between Microsoft Edge (client side rendering) and Node's V8 (server side rendering) for the Intl implementation.

This change omits the use of en-US as the configured locale and falls back to the browser default. This sees a significant reduction in the mismatch between the way languages are rendered between browsers (and V8 on the server).