### PR TITLE
chore: [] Sentry tweaks

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -95,6 +95,7 @@ const moduleExports = withPlugins(plugins, {
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
     // for more information.
     hideSourceMaps: true,
+    widenClientFileUpload: true,
   },
 });
 


### PR DESCRIPTION
## Purpose of PR

- Lots of our errors stem from js chunk, according to thw docs adding `widenClientFileUpload` might add some clarity to those traces: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#widen-the-upload-scope
