### PR TITLE
feat: [PLATO-444] Refetch on focus

### DIFF
--- a/src/lib/gql-client.ts
+++ b/src/lib/gql-client.ts
@@ -10,9 +10,9 @@ export const queryConfig = {
   defaultOptions: {
     queries: {
       retry: false,
-      refetchOnMount: false,
+      refetchOnMount: true,
       refetchIntervalInBackground: false,
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
     },
   },
 };


### PR DESCRIPTION
## Purpose of PR

- The RQ provider now refetched on window focus, so when changing data in Contentful, switching back to the window will immediately refetch the data

https://contentful.atlassian.net/browse/PLATO-444
