### PR TITLE
feat: [PLATO-411] Tracking events

### DIFF
--- a/analytics/index.ts
+++ b/analytics/index.ts
@@ -3,45 +3,105 @@
 //   npx typewriter
 
 /**
- * test2
+ * Fired when a user clicks any of the links to the content models visible when the x-ray
+ * mode is active.
  */
-export interface DemoEvent {
-    bestCompany?: string;
+export interface ContentModelInteracted {
+    /**
+     * The internal name for a content model in Contentful. This is a custom field specific to
+     * templates.
+     */
+    entryInternalName?: string;
+    /**
+     * Direct link to the entry in Contentful
+     */
+    entryLink: string;
+    /**
+     * The __typeName for an entry
+     */
+    entryTypeName: string;
     [property: string]: any;
 }
 
 /**
- * test
+ * Fired when a guest space is active. A guest space is active when at least a spaceId, CDA
+ * token and CPA token are provided as url parameters. Optionally a domain can be passed.
+ *
+ * Guest spaces are used for Contentful’s Entry preview links.
  */
-export interface Test {
+export interface GuestSpaceActive {
     /**
-     * Company
+     * Unique id of a user's space
      */
-    company?: string;
-    /**
-     * Name...
-     */
-    name: string;
+    spaceId: string;
+    [property: string]: any;
+}
+
+/**
+ * Fired when a user interacts with the preview mode checkbox in the editorial toolbox.
+ */
+export interface PreviewModeInteracted {
+    enabled: boolean;
+    [property: string]: any;
+}
+
+/**
+ * Fired when the editorial opens or closes
+ */
+export interface ToolboxInteracted {
+    isOpen: boolean;
+    [property: string]: any;
+}
+
+/**
+ * Fired when a user interacts with the X-ray mode checkbox in the editorial toolbox.
+ */
+export interface XrayModeInteracted {
+    enabled: boolean;
     [property: string]: any;
 }
 
 // Converts JSON strings to/from your types
 // and asserts the results of JSON.parse at runtime
 export class Convert {
-    public static toDemoEvent(json: string): DemoEvent {
-        return cast(JSON.parse(json), r("DemoEvent"));
+    public static toContentModelInteracted(json: string): ContentModelInteracted {
+        return cast(JSON.parse(json), r("ContentModelInteracted"));
     }
 
-    public static demoEventToJson(value: DemoEvent): string {
-        return JSON.stringify(uncast(value, r("DemoEvent")), null, 2);
+    public static contentModelInteractedToJson(value: ContentModelInteracted): string {
+        return JSON.stringify(uncast(value, r("ContentModelInteracted")), null, 2);
     }
 
-    public static toTest(json: string): Test {
-        return cast(JSON.parse(json), r("Test"));
+    public static toGuestSpaceActive(json: string): GuestSpaceActive {
+        return cast(JSON.parse(json), r("GuestSpaceActive"));
     }
 
-    public static testToJson(value: Test): string {
-        return JSON.stringify(uncast(value, r("Test")), null, 2);
+    public static guestSpaceActiveToJson(value: GuestSpaceActive): string {
+        return JSON.stringify(uncast(value, r("GuestSpaceActive")), null, 2);
+    }
+
+    public static toPreviewModeInteracted(json: string): PreviewModeInteracted {
+        return cast(JSON.parse(json), r("PreviewModeInteracted"));
+    }
+
+    public static previewModeInteractedToJson(value: PreviewModeInteracted): string {
+        return JSON.stringify(uncast(value, r("PreviewModeInteracted")), null, 2);
+    }
+
+    public static toToolboxInteracted(json: string): ToolboxInteracted {
+        return cast(JSON.parse(json), r("ToolboxInteracted"));
+    }
+
+    public static toolboxInteractedToJson(value: ToolboxInteracted): string {
+        return JSON.stringify(uncast(value, r("ToolboxInteracted")), null, 2);
+    }
+
+    public static toXrayModeInteracted(json: string): XrayModeInteracted {
+        return cast(JSON.parse(json), r("XrayModeInteracted"));
+    }
+
+    public static xrayModeInteractedToJson(value: XrayModeInteracted): string {
+        return JSON.stringify(uncast(value, r("XrayModeInteracted")), null, 2);
     }
 }
 
@@ -178,12 +238,22 @@ function r(name: string) {
 }
 
 const typeMap: any = {
-    "DemoEvent": o([
-        { json: "bestCompany", js: "bestCompany", typ: u(undefined, "") },
+    "ContentModelInteracted": o([
+        { json: "entryInternalName", js: "entryInternalName", typ: u(undefined, "") },
+        { json: "entryLink", js: "entryLink", typ: "" },
+        { json: "entryTypeName", js: "entryTypeName", typ: "" },
     ], "any"),
-    "Test": o([
-        { json: "company", js: "company", typ: u(undefined, "") },
-        { json: "name", js: "name", typ: "" },
+    "GuestSpaceActive": o([
+        { json: "spaceId", js: "spaceId", typ: "" },
+    ], "any"),
+    "PreviewModeInteracted": o([
+        { json: "enabled", js: "enabled", typ: true },
+    ], "any"),
+    "ToolboxInteracted": o([
+        { json: "isOpen", js: "isOpen", typ: true },
+    ], "any"),
+    "XrayModeInteracted": o([
+        { json: "enabled", js: "enabled", typ: true },
     ], "any"),
 };
 
@@ -398,21 +468,21 @@ function withTypewriterContext(message: Options = {}): Options {
 }
 
 /**
- * Fires a 'DemoEvent' track call.
+ * Fires a 'ContentModelInteracted' track call.
  *
- * @param DemoEvent props - The analytics properties that will be sent to Segment.
+ * @param ContentModelInteracted props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
  * 	call is fired.
  */
-export function demoEvent(props: DemoEvent, options?: Options, callback?: Callback): void {
+export function contentModelInteracted(props: ContentModelInteracted, options?: Options, callback?: Callback): void {
 
-    const schema = {"$id":"demoEvent","description":"test2","properties":{"bestCompany":{"$id":"/properties/bestCompany","description":"","type":"string"}},"type":"object"};
+    const schema = {"$id":"content_model_interacted","description":"Fired when a user clicks any of the links to the content models visible when the x-ray mode is active.","properties":{"entryInternalName":{"$id":"/properties/entryInternalName","description":"The internal name for a content model in Contentful. This is a custom field specific to templates.","type":"string"},"entryLink":{"$id":"/properties/entryLink","description":"Direct link to the entry in Contentful","type":"string"},"entryTypeName":{"$id":"/properties/entryTypeName","description":"The __typeName for an entry","type":"string"}},"required":["entryTypeName","entryLink"],"type":"object"};
     validateAgainstSchema(props, schema);
 
     const a = analytics();
     if (a) {
-        a.track('demoEvent', props || {}, {...options,   context: {
+        a.track('content_model_interacted', props || {}, {...options,   context: {
             ...(options?.context || {}),
             typewriter: {
                 language: 'typescript',
@@ -422,21 +492,93 @@ export function demoEvent(props: DemoEvent, options?: Options, callback?: Callba
     }
 }
 /**
- * Fires a 'Test' track call.
+ * Fires a 'GuestSpaceActive' track call.
  *
- * @param Test props - The analytics properties that will be sent to Segment.
+ * @param GuestSpaceActive props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
  * 	call is fired.
  */
-export function test(props: Test, options?: Options, callback?: Callback): void {
+export function guestSpaceActive(props: GuestSpaceActive, options?: Options, callback?: Callback): void {
 
-    const schema = {"$id":"test","description":"test","properties":{"company":{"$id":"/properties/company","description":"Company","type":"string"},"name":{"$id":"/properties/name","description":"Name...","type":"string"}},"required":["name"],"type":"object"};
+    const schema = {"$id":"guest_space_active","description":"Fired when a guest space is active. A guest space is active when at least a spaceId, CDA token and CPA token are provided as url parameters. Optionally a domain can be passed.\n\nGuest spaces are used for Contentful’s Entry preview links.","properties":{"spaceId":{"$id":"/properties/spaceId","description":"Unique id of a user's space","type":"string"}},"required":["spaceId"],"type":"object"};
     validateAgainstSchema(props, schema);
 
     const a = analytics();
     if (a) {
-        a.track('test', props || {}, {...options,   context: {
+        a.track('guest_space_active', props || {}, {...options,   context: {
+            ...(options?.context || {}),
+            typewriter: {
+                language: 'typescript',
+                version: '',
+            },
+        },}, callback);
+    }
+}
+/**
+ * Fires a 'PreviewModeInteracted' track call.
+ *
+ * @param PreviewModeInteracted props - The analytics properties that will be sent to Segment.
+ * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+ * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+ * 	call is fired.
+ */
+export function previewModeInteracted(props: PreviewModeInteracted, options?: Options, callback?: Callback): void {
+
+    const schema = {"$id":"preview_mode_interacted","description":"Fired when a user interacts with the preview mode checkbox in the editorial toolbox.","properties":{"enabled":{"$id":"/properties/enabled","description":"","type":"boolean"}},"required":["enabled"],"type":"object"};
+    validateAgainstSchema(props, schema);
+
+    const a = analytics();
+    if (a) {
+        a.track('preview_mode_interacted', props || {}, {...options,   context: {
+            ...(options?.context || {}),
+            typewriter: {
+                language: 'typescript',
+                version: '',
+            },
+        },}, callback);
+    }
+}
+/**
+ * Fires a 'ToolboxInteracted' track call.
+ *
+ * @param ToolboxInteracted props - The analytics properties that will be sent to Segment.
+ * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+ * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+ * 	call is fired.
+ */
+export function toolboxInteracted(props: ToolboxInteracted, options?: Options, callback?: Callback): void {
+
+    const schema = {"$id":"toolbox_interacted","description":"Fired when the editorial opens or closes","properties":{"isOpen":{"$id":"/properties/isOpen","description":"","type":"boolean"}},"required":["isOpen"],"type":"object"};
+    validateAgainstSchema(props, schema);
+
+    const a = analytics();
+    if (a) {
+        a.track('toolbox_interacted', props || {}, {...options,   context: {
+            ...(options?.context || {}),
+            typewriter: {
+                language: 'typescript',
+                version: '',
+            },
+        },}, callback);
+    }
+}
+/**
+ * Fires a 'XrayModeInteracted' track call.
+ *
+ * @param XrayModeInteracted props - The analytics properties that will be sent to Segment.
+ * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+ * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+ * 	call is fired.
+ */
+export function xrayModeInteracted(props: XrayModeInteracted, options?: Options, callback?: Callback): void {
+
+    const schema = {"$id":"xray_mode_interacted","description":"Fired when a user interacts with the X-ray mode checkbox in the editorial toolbox.","properties":{"enabled":{"$id":"/properties/enabled","description":"","type":"boolean"}},"required":["enabled"],"type":"object"};
+    validateAgainstSchema(props, schema);
+
+    const a = analytics();
+    if (a) {
+        a.track('xray_mode_interacted', props || {}, {...options,   context: {
             ...(options?.context || {}),
             typewriter: {
                 language: 'typescript',
@@ -463,23 +605,50 @@ const clientAPI = {
     setTypewriterOptions,
 
     /**
-     * Fires a 'DemoEvent' track call.
+     * Fires a 'ContentModelInteracted' track call.
      *
-     * @param DemoEvent props - The analytics properties that will be sent to Segment.
+     * @param ContentModelInteracted props - The analytics properties that will be sent to Segment.
      * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
      * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
      * 	call is fired.
      */
-    demoEvent,
+    contentModelInteracted,
     /**
-     * Fires a 'Test' track call.
+     * Fires a 'GuestSpaceActive' track call.
      *
-     * @param Test props - The analytics properties that will be sent to Segment.
+     * @param GuestSpaceActive props - The analytics properties that will be sent to Segment.
      * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
      * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
      * 	call is fired.
      */
-    test,
+    guestSpaceActive,
+    /**
+     * Fires a 'PreviewModeInteracted' track call.
+     *
+     * @param PreviewModeInteracted props - The analytics properties that will be sent to Segment.
+     * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+     * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+     * 	call is fired.
+     */
+    previewModeInteracted,
+    /**
+     * Fires a 'ToolboxInteracted' track call.
+     *
+     * @param ToolboxInteracted props - The analytics properties that will be sent to Segment.
+     * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+     * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+     * 	call is fired.
+     */
+    toolboxInteracted,
+    /**
+     * Fires a 'XrayModeInteracted' track call.
+     *
+     * @param XrayModeInteracted props - The analytics properties that will be sent to Segment.
+     * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+     * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+     * 	call is fired.
+     */
+    xrayModeInteracted,
 };
 
 export default new Proxy<typeof clientAPI>(clientAPI, {

--- a/analytics/plan.json
+++ b/analytics/plan.json
@@ -2,65 +2,146 @@
   "createdAt": "2023-01-26T13:06:13.000Z",
   "description": "description",
   "id": "tp_2Krgyyk8cetTMKJ22QpFo62PiX9",
-  "name": "starter-templates-plato",
+  "name": "starter-templates",
   "resourceSchemaId": "rs_2KrgyvdUzeotA4PnzVlzLMAMdHV",
   "rules": [
     {
-      "createdAt": "2023-01-30T09:24:29.000Z",
+      "createdAt": "2023-02-16T15:29:59.000Z",
       "deprecatedAt": "0001-01-01T00:00:00.000Z",
       "jsonSchema": {
-        "$id": "demoEvent",
-        "description": "test2",
+        "$id": "content_model_interacted",
+        "description": "Fired when a user clicks any of the links to the content models visible when the x-ray mode is active.",
         "eventMetadata": {
-          "name": "demoEvent",
+          "name": "content_model_interacted",
           "type": "TRACK"
         },
         "properties": {
-          "bestCompany": {
-            "$id": "/properties/bestCompany",
-            "description": "",
+          "entryInternalName": {
+            "$id": "/properties/entryInternalName",
+            "description": "The internal name for a content model in Contentful. This is a custom field specific to templates.",
+            "type": "string"
+          },
+          "entryLink": {
+            "$id": "/properties/entryLink",
+            "description": "Direct link to the entry in Contentful",
+            "type": "string"
+          },
+          "entryTypeName": {
+            "$id": "/properties/entryTypeName",
+            "description": "The __typeName for an entry",
             "type": "string"
           }
         },
+        "required": ["entryTypeName", "entryLink"],
         "type": "object"
       },
-      "key": "demoEvent",
+      "key": "content_model_interacted",
       "type": "TRACK",
-      "updatedAt": "2023-01-30T09:24:29.000Z",
+      "updatedAt": "2023-02-21T10:25:37.000Z",
       "version": 1
     },
     {
-      "createdAt": "2023-01-26T13:07:54.000Z",
+      "createdAt": "2023-02-16T15:29:59.000Z",
       "deprecatedAt": "0001-01-01T00:00:00.000Z",
       "jsonSchema": {
-        "$id": "test",
-        "description": "test",
+        "$id": "guest_space_active",
+        "description": "Fired when a guest space is active. A guest space is active when at least a spaceId, CDA token and CPA token are provided as url parameters. Optionally a domain can be passed.\n\nGuest spaces are used for Contentful’s Entry preview links.",
         "eventMetadata": {
-          "name": "test",
+          "name": "guest_space_active",
           "type": "TRACK"
         },
         "properties": {
-          "company": {
-            "$id": "/properties/company",
-            "description": "Company",
-            "type": "string"
-          },
-          "name": {
-            "$id": "/properties/name",
-            "description": "Name...",
+          "spaceId": {
+            "$id": "/properties/spaceId",
+            "description": "Unique id of a user's space",
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": ["spaceId"],
         "type": "object"
       },
-      "key": "test",
+      "key": "guest_space_active",
       "type": "TRACK",
-      "updatedAt": "2023-01-27T09:59:48.000Z",
+      "updatedAt": "2023-02-21T10:25:37.000Z",
+      "version": 1
+    },
+    {
+      "createdAt": "2023-02-16T15:29:59.000Z",
+      "deprecatedAt": "0001-01-01T00:00:00.000Z",
+      "jsonSchema": {
+        "$id": "preview_mode_interacted",
+        "description": "Fired when a user interacts with the preview mode checkbox in the editorial toolbox.",
+        "eventMetadata": {
+          "name": "preview_mode_interacted",
+          "type": "TRACK"
+        },
+        "properties": {
+          "enabled": {
+            "$id": "/properties/enabled",
+            "description": "",
+            "type": "boolean"
+          }
+        },
+        "required": ["enabled"],
+        "type": "object"
+      },
+      "key": "preview_mode_interacted",
+      "type": "TRACK",
+      "updatedAt": "2023-02-21T10:25:37.000Z",
+      "version": 1
+    },
+    {
+      "createdAt": "2023-02-21T10:04:59.000Z",
+      "deprecatedAt": "0001-01-01T00:00:00.000Z",
+      "jsonSchema": {
+        "$id": "toolbox_interacted",
+        "description": "Fired when the editorial opens or closes",
+        "eventMetadata": {
+          "name": "toolbox_interacted",
+          "type": "TRACK"
+        },
+        "properties": {
+          "isOpen": {
+            "$id": "/properties/isOpen",
+            "description": "",
+            "type": "boolean"
+          }
+        },
+        "required": ["isOpen"],
+        "type": "object"
+      },
+      "key": "toolbox_interacted",
+      "type": "TRACK",
+      "updatedAt": "2023-02-21T10:25:37.000Z",
+      "version": 1
+    },
+    {
+      "createdAt": "2023-02-16T15:29:59.000Z",
+      "deprecatedAt": "0001-01-01T00:00:00.000Z",
+      "jsonSchema": {
+        "$id": "xray_mode_interacted",
+        "description": "Fired when a user interacts with the X-ray mode checkbox in the editorial toolbox.",
+        "eventMetadata": {
+          "name": "xray_mode_interacted",
+          "type": "TRACK"
+        },
+        "properties": {
+          "enabled": {
+            "$id": "/properties/enabled",
+            "description": "",
+            "type": "boolean"
+          }
+        },
+        "required": ["enabled"],
+        "type": "object"
+      },
+      "key": "xray_mode_interacted",
+      "type": "TRACK",
+      "updatedAt": "2023-02-21T10:25:37.000Z",
       "version": 1
     }
   ],
   "slug": "",
   "type": "LIVE",
-  "updatedAt": "2023-01-31T12:12:51.000Z"
+  "updatedAt": "2023-02-21T16:55:46.000Z"
 }

--- a/src/_ctf-private/ctf-analytics/CtfSegmentAnalytics.tsx
+++ b/src/_ctf-private/ctf-analytics/CtfSegmentAnalytics.tsx
@@ -1,19 +1,50 @@
 import * as Sentry from '@sentry/browser';
+import { useRouter } from 'next/router';
 import Script from 'next/script';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import { useCtfConsent } from '../ctf-consent-management/useCtfConsent';
+import { useCtfConsent } from '../ctf-consent-management';
 
 import typewriter from 'analytics';
 
 export const CtfSegmentAnalytics = () => {
+  const router = useRouter();
+  const { xray, preview, space_id, preview_token, delivery_token } = router.query;
+
   const [initialized, setInitialized] = useState(false);
+  const [initialPageViewFired, setInitialPageViewFired] = useState(false);
+
+  const guestSpaceActive = !!space_id && !!preview_token && !!delivery_token;
 
   const { data } = useCtfConsent();
 
   data?.on('initialized', () => {
     setInitialized(true);
   });
+
+  const handleRouteChange = useCallback(() => {
+    if (initialized && analytics) {
+      analytics.page({
+        templateId: 'marketing',
+        xRayActive: Boolean(xray),
+        previewActive: Boolean(preview),
+        guestSpaceActive: Boolean(guestSpaceActive),
+      });
+    }
+  }, [guestSpaceActive, initialized, preview, xray]);
+
+  useEffect(() => {
+    if (guestSpaceActive && initialized) {
+      typewriter.guestSpaceActive({ spaceId: String(space_id) });
+    }
+  }, [guestSpaceActive, initialized, space_id]);
+
+  useEffect(() => {
+    if (initialized && !initialPageViewFired) {
+      handleRouteChange();
+      setInitialPageViewFired(true);
+    }
+  }, [initialized, initialPageViewFired, handleRouteChange]);
 
   useEffect(() => {
     typewriter.setTypewriterOptions({
@@ -35,14 +66,19 @@ export const CtfSegmentAnalytics = () => {
         }
       },
     });
-  }, []);
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [handleRouteChange, router.events]);
 
   return initialized ? (
     <Script id="segment-tracking-script">
       {`
         !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${process.env.NEXT_PUBLIC_SEGMENT_WRITEKEY}";;analytics.SNIPPET_VERSION="4.15.3";
         analytics.load("${process.env.NEXT_PUBLIC_SEGMENT_WRITEKEY}");
-        analytics.page();
         }}();
       `}
     </Script>

--- a/src/components/features/settings/settings-form.tsx
+++ b/src/components/features/settings/settings-form.tsx
@@ -11,10 +11,11 @@ import { makeStyles } from '@mui/styles';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import { useContentfulContext } from '@src/contentful-context';
 import SettingsIcon from '@src/icons/settings-icon.svg';
+import typewriter from 'analytics';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -250,7 +251,7 @@ interface SettingsFormPropsInterface {
   onClose: () => void;
 }
 
-export const SettingsForm: React.FC<SettingsFormPropsInterface> = props => {
+export const SettingsForm = forwardRef<HTMLDivElement, SettingsFormPropsInterface>((props, ref) => {
   const { onClose } = props;
   const router = useRouter();
 
@@ -272,16 +273,32 @@ export const SettingsForm: React.FC<SettingsFormPropsInterface> = props => {
     if (xrayActive !== newXrayActive) {
       if (newXrayActive === false) {
         delete queryParams.xray;
+
+        typewriter.xrayModeInteracted({
+          enabled: false,
+        });
       } else {
         queryParams.xray = '1';
+
+        typewriter.xrayModeInteracted({
+          enabled: true,
+        });
       }
     }
 
     if (previewActive !== newPreviewActive) {
       if (newPreviewActive === false) {
         delete queryParams.preview;
+
+        typewriter.previewModeInteracted({
+          enabled: false,
+        });
       } else {
         queryParams.preview = '1';
+
+        typewriter.previewModeInteracted({
+          enabled: true,
+        });
       }
     }
 
@@ -294,7 +311,7 @@ export const SettingsForm: React.FC<SettingsFormPropsInterface> = props => {
   };
 
   return (
-    <section className={classes.root}>
+    <section className={classes.root} ref={ref}>
       <header className={classes.header}>
         <SettingsIcon className={classes.logo} />
         <Typography className={classes.headerTitle} variant="h1">
@@ -375,4 +392,4 @@ export const SettingsForm: React.FC<SettingsFormPropsInterface> = props => {
       </div>
     </section>
   );
-};
+});

--- a/src/components/shared/xray-frame.tsx
+++ b/src/components/shared/xray-frame.tsx
@@ -1,9 +1,11 @@
 import { Box, Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import clsx from 'clsx';
+import { useRouter } from 'next/router';
 import React from 'react';
 
 import { useContentfulContext } from '@src/contentful-context';
+import typewriter from 'analytics';
 
 const useStyles = makeStyles((theme: Theme) => ({
   xframeRoot: {
@@ -25,6 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 
   label: {
+    cursor: 'pointer',
     background: '#EAEAEA',
     display: 'inline-block',
     maxWidth: '100%',
@@ -53,22 +56,38 @@ interface Props {
 }
 
 export const XrayFrame = (props: Props) => {
+  const router = useRouter();
   const contentfulContext = useContentfulContext();
+  const { domain = 'contentful.com' } = router.query;
+
   const {
     spaceIds: { main: spaceId },
   } = contentfulContext;
   const classes = useStyles();
-  const contentfulUrl = `https://app.contentful.com/spaces/${spaceId}/entries/${props.sys.id}`; // TODO: replace me as well for https://contentful.atlassian.net/browse/PLATO-203
+  const contentfulUrl = `https://app.${domain}/spaces/${spaceId}/entries/${props.sys.id}`;
+
+  const handleOnClick = e => {
+    e.stopPropagation();
+
+    typewriter.contentModelInteracted({
+      entryTypeName: props.__typename || '',
+      entryInternalName: props.internalName || '',
+      entryLink: contentfulUrl,
+    });
+
+    window.open(contentfulUrl, '_blank', 'noopener noreferrer');
+  };
+
   return (
     <Box className={clsx(classes.xframeRoot, props.className)}>
       {props.children}
       <Box className={classes.frame}>
-        <a href={contentfulUrl} target="_blank" rel="noopener noreferrer" className={classes.label}>
+        <button onClick={handleOnClick} className={classes.label}>
           <Typography>
             <strong>{props.__typename}</strong>
             {props.internalName && <span> | {props.internalName}</span>}
           </Typography>
-        </a>
+        </button>
       </Box>
     </Box>
   );


### PR DESCRIPTION
**_What will change?_**

- Added Segment tracking events
- The toolbox now closes on clicks outside of it, and pressing the escape key
- Fixed an issue where the xray frame would nest anchors in anchors causing a HTML error
- Included the possibility to add a custom domain to the xray mode links

Ticket: https://contentful.atlassian.net/browse/PLATO-411
Tracking plan: https://contentful.atlassian.net/wiki/spaces/PROD/pages/4138500311/Templates+-+Segment+tracking#Tracking-plan

**_Testing steps_**
- Make sure `analytics` cookies are accepted and AdBlockers are disabled (confirm there's no errors being thrown in the browser's console)
- Make sure all events mentioned in the tracking plan, are correctly implemented and fired accordingly. This can be checked with the Segment Debugger, available in our staging environment. Credentials can be found on 1 password
- We are aware that addition `page` events are fired when URL parameters change (this happens for the preview and xray mode). This is an accepted side effect.

## TODO

- [ ] Check the events on Segment production after the merge.
- [ ] Check potential script/cookies to be added to the Osano configuration - taken care of in https://contentful.atlassian.net/browse/PLATO-467.