### PR TITLE
docs: [PLATO-501] update sign-up links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ $~$
 The Starter Templates experience is currently only available to new users.
 
 To benefit from this experience, please follow this link to create a new
-account: [https://www.contentful.com/sign-up/?action=create_starter_template](https://www.contentful.com/sign-up/?action=create_starter_template&utm_source=github.com&utm_medium=referral&utm_campaign=template-marketing-webapp-nextjs).
+account and select the template to install: [https://www.contentful.com/starter-templates/marketing-website/sign-up/?action=create_starter_template](https://www.contentful.com/starter-templates/marketing-website/sign-up/?action=create_starter_template&utm_source=github.com&utm_medium=referral&utm_campaign=template-marketing-webapp-nextjs).
 
-To immediately start auto installation of this template after creating a new account,
-please follow this link:
-[https://www.contentful.com/sign-up/?action=create_starter_template&template_name=marketing](https://www.contentful.com/sign-up/?action=create_starter_template&template_name=marketing&utm_source=github.com&utm_medium=referral&utm_campaign=template-marketing-webapp-nextjs).
+Alternatively, to immediately start the auto installation of this template after creating a new account, please follow this link:
+[https://www.contentful.com/starter-templates/marketing-website/sign-up/?action=create_starter_template&template_name=marketing](https://www.contentful.com/starter-templates/marketing-website/sign-up/?action=create_starter_template&template_name=marketing&utm_source=github.com&utm_medium=referral&utm_campaign=template-marketing-webapp-nextjs).
 
 $~$
 


### PR DESCRIPTION
**_What will change?_**

This work consolidates the sign-up links to align with our Marketing efforts and adjusts the wording of the sign-up process to avoid confusion among the users.

The sign-up form now shows template-specific content in the left sidebar.

<img width="1498" alt="Screenshot 2023-04-11 at 14 51 44" src="https://user-images.githubusercontent.com/103024358/231168027-da255c43-2c67-40e5-9dcd-5db79fb57baf.png">
