### PR TITLE
fix: [] fix-graphql-fields-narrowing

### DIFF
--- a/src/components/features/ctf-components/ctf-page/__generated/ctf-page.generated.ts
+++ b/src/components/features/ctf-components/ctf-page/__generated/ctf-page.generated.ts
@@ -1,10 +1,8 @@
 import * as Types from '../../../../../lib/__generated/graphql.types';
 
 import { AssetFieldsFragment } from '../../ctf-asset/__generated/ctf-asset.generated';
-import { ComponentReferenceFields_ComponentCta_Fragment, ComponentReferenceFields_ComponentDuplex_Fragment, ComponentReferenceFields_ComponentHeroBanner_Fragment, ComponentReferenceFields_ComponentInfoBlock_Fragment, ComponentReferenceFields_ComponentProductTable_Fragment, ComponentReferenceFields_ComponentQuote_Fragment, ComponentReferenceFields_ComponentTextBlock_Fragment, ComponentReferenceFields_FooterMenu_Fragment, ComponentReferenceFields_MenuGroup_Fragment, ComponentReferenceFields_NavigationMenu_Fragment, ComponentReferenceFields_Page_Fragment, ComponentReferenceFields_Seo_Fragment, ComponentReferenceFields_TopicBusinessInfo_Fragment, ComponentReferenceFields_TopicPerson_Fragment, ComponentReferenceFields_TopicProduct_Fragment, ComponentReferenceFields_TopicProductFeature_Fragment } from '../../../../../lib/shared-fragments/__generated/ctf-componentMap.generated';
 import { fetchConfig } from '@src/lib/fetchConfig';
 import { AssetFieldsFragmentDoc } from '../../ctf-asset/__generated/ctf-asset.generated';
-import { ComponentReferenceFieldsFragmentDoc } from '../../../../../lib/shared-fragments/__generated/ctf-componentMap.generated';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
@@ -26,54 +24,90 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
     return json.data;
   }
 }
+export type PageTopSectionFields_ComponentCta_Fragment = { __typename: 'ComponentCta', internalName?: string | null };
+
+export type PageTopSectionFields_ComponentDuplex_Fragment = { __typename: 'ComponentDuplex', internalName?: string | null };
+
+export type PageTopSectionFields_ComponentHeroBanner_Fragment = { __typename: 'ComponentHeroBanner', internalName?: string | null };
+
+export type PageTopSectionFields_ComponentInfoBlock_Fragment = { __typename: 'ComponentInfoBlock', internalName?: string | null };
+
+export type PageTopSectionFields_ComponentQuote_Fragment = { __typename: 'ComponentQuote', internalName?: string | null };
+
+export type PageTopSectionFields_ComponentTextBlock_Fragment = { __typename: 'ComponentTextBlock', internalName?: string | null };
+
+export type PageTopSectionFieldsFragment = PageTopSectionFields_ComponentCta_Fragment | PageTopSectionFields_ComponentDuplex_Fragment | PageTopSectionFields_ComponentHeroBanner_Fragment | PageTopSectionFields_ComponentInfoBlock_Fragment | PageTopSectionFields_ComponentQuote_Fragment | PageTopSectionFields_ComponentTextBlock_Fragment;
+
+export type PageContentFields_ComponentProductTable_Fragment = { __typename: 'ComponentProductTable', internalName?: string | null };
+
+export type PageContentFields_TopicBusinessInfo_Fragment = { __typename: 'TopicBusinessInfo', internalName?: string | null };
+
+export type PageContentFields_TopicProduct_Fragment = { __typename: 'TopicProduct', internalName?: string | null };
+
+export type PageContentFieldsFragment = PageContentFields_ComponentProductTable_Fragment | PageContentFields_TopicBusinessInfo_Fragment | PageContentFields_TopicProduct_Fragment;
+
+export type PageExtraSectionItemFields_ComponentCta_Fragment = { __typename: 'ComponentCta', internalName?: string | null };
+
+export type PageExtraSectionItemFields_ComponentDuplex_Fragment = { __typename: 'ComponentDuplex', internalName?: string | null };
+
+export type PageExtraSectionItemFields_ComponentHeroBanner_Fragment = { __typename: 'ComponentHeroBanner', internalName?: string | null };
+
+export type PageExtraSectionItemFields_ComponentInfoBlock_Fragment = { __typename: 'ComponentInfoBlock', internalName?: string | null };
+
+export type PageExtraSectionItemFields_ComponentQuote_Fragment = { __typename: 'ComponentQuote', internalName?: string | null };
+
+export type PageExtraSectionItemFields_ComponentTextBlock_Fragment = { __typename: 'ComponentTextBlock', internalName?: string | null };
+
+export type PageExtraSectionItemFieldsFragment = PageExtraSectionItemFields_ComponentCta_Fragment | PageExtraSectionItemFields_ComponentDuplex_Fragment | PageExtraSectionItemFields_ComponentHeroBanner_Fragment | PageExtraSectionItemFields_ComponentInfoBlock_Fragment | PageExtraSectionItemFields_ComponentQuote_Fragment | PageExtraSectionItemFields_ComponentTextBlock_Fragment;
+
 export type CtfPageFieldsFragment = { __typename?: 'Page', pageName?: string | null, slug?: string | null, internalName?: string | null, seo?: { __typename?: 'Seo', title?: string | null, description?: string | null, noIndex?: boolean | null, noFollow?: boolean | null, image?: (
       { __typename?: 'Asset' }
       & AssetFieldsFragment
     ) | null } | null, topSectionCollection?: { __typename?: 'PageTopSectionCollection', items: Array<(
-      { __typename?: 'ComponentCta' }
-      & ComponentReferenceFields_ComponentCta_Fragment
+      { __typename: 'ComponentCta', sys: { __typename?: 'Sys', id: string } }
+      & PageTopSectionFields_ComponentCta_Fragment
     ) | (
-      { __typename?: 'ComponentDuplex' }
-      & ComponentReferenceFields_ComponentDuplex_Fragment
+      { __typename: 'ComponentDuplex', sys: { __typename?: 'Sys', id: string } }
+      & PageTopSectionFields_ComponentDuplex_Fragment
     ) | (
-      { __typename?: 'ComponentHeroBanner' }
-      & ComponentReferenceFields_ComponentHeroBanner_Fragment
+      { __typename: 'ComponentHeroBanner', sys: { __typename?: 'Sys', id: string } }
+      & PageTopSectionFields_ComponentHeroBanner_Fragment
     ) | (
-      { __typename?: 'ComponentInfoBlock' }
-      & ComponentReferenceFields_ComponentInfoBlock_Fragment
+      { __typename: 'ComponentInfoBlock', sys: { __typename?: 'Sys', id: string } }
+      & PageTopSectionFields_ComponentInfoBlock_Fragment
     ) | (
-      { __typename?: 'ComponentQuote' }
-      & ComponentReferenceFields_ComponentQuote_Fragment
+      { __typename: 'ComponentQuote', sys: { __typename?: 'Sys', id: string } }
+      & PageTopSectionFields_ComponentQuote_Fragment
     ) | (
-      { __typename?: 'ComponentTextBlock' }
-      & ComponentReferenceFields_ComponentTextBlock_Fragment
+      { __typename: 'ComponentTextBlock', sys: { __typename?: 'Sys', id: string } }
+      & PageTopSectionFields_ComponentTextBlock_Fragment
     ) | null> } | null, pageContent?: (
-    { __typename?: 'ComponentProductTable' }
-    & ComponentReferenceFields_ComponentProductTable_Fragment
+    { __typename: 'ComponentProductTable', sys: { __typename?: 'Sys', id: string } }
+    & PageContentFields_ComponentProductTable_Fragment
   ) | (
-    { __typename?: 'TopicBusinessInfo' }
-    & ComponentReferenceFields_TopicBusinessInfo_Fragment
+    { __typename: 'TopicBusinessInfo', sys: { __typename?: 'Sys', id: string } }
+    & PageContentFields_TopicBusinessInfo_Fragment
   ) | (
-    { __typename?: 'TopicProduct' }
-    & ComponentReferenceFields_TopicProduct_Fragment
+    { __typename: 'TopicProduct', sys: { __typename?: 'Sys', id: string } }
+    & PageContentFields_TopicProduct_Fragment
   ) | null, extraSectionCollection?: { __typename?: 'PageExtraSectionCollection', items: Array<(
-      { __typename?: 'ComponentCta' }
-      & ComponentReferenceFields_ComponentCta_Fragment
+      { __typename: 'ComponentCta', sys: { __typename?: 'Sys', id: string } }
+      & PageExtraSectionItemFields_ComponentCta_Fragment
     ) | (
-      { __typename?: 'ComponentDuplex' }
-      & ComponentReferenceFields_ComponentDuplex_Fragment
+      { __typename: 'ComponentDuplex', sys: { __typename?: 'Sys', id: string } }
+      & PageExtraSectionItemFields_ComponentDuplex_Fragment
     ) | (
-      { __typename?: 'ComponentHeroBanner' }
-      & ComponentReferenceFields_ComponentHeroBanner_Fragment
+      { __typename: 'ComponentHeroBanner', sys: { __typename?: 'Sys', id: string } }
+      & PageExtraSectionItemFields_ComponentHeroBanner_Fragment
     ) | (
-      { __typename?: 'ComponentInfoBlock' }
-      & ComponentReferenceFields_ComponentInfoBlock_Fragment
+      { __typename: 'ComponentInfoBlock', sys: { __typename?: 'Sys', id: string } }
+      & PageExtraSectionItemFields_ComponentInfoBlock_Fragment
     ) | (
-      { __typename?: 'ComponentQuote' }
-      & ComponentReferenceFields_ComponentQuote_Fragment
+      { __typename: 'ComponentQuote', sys: { __typename?: 'Sys', id: string } }
+      & PageExtraSectionItemFields_ComponentQuote_Fragment
     ) | (
-      { __typename?: 'ComponentTextBlock' }
-      & ComponentReferenceFields_ComponentTextBlock_Fragment
+      { __typename: 'ComponentTextBlock', sys: { __typename?: 'Sys', id: string } }
+      & PageExtraSectionItemFields_ComponentTextBlock_Fragment
     ) | null> } | null };
 
 export type CtfPageQueryVariables = Types.Exact<{
@@ -88,6 +122,66 @@ export type CtfPageQuery = { __typename?: 'Query', pageCollection?: { __typename
       & CtfPageFieldsFragment
     ) | null> } | null };
 
+export const PageTopSectionFieldsFragmentDoc = `
+    fragment PageTopSectionFields on PageTopSectionItem {
+  __typename
+  ... on ComponentCta {
+    internalName
+  }
+  ... on ComponentDuplex {
+    internalName
+  }
+  ... on ComponentHeroBanner {
+    internalName
+  }
+  ... on ComponentInfoBlock {
+    internalName
+  }
+  ... on ComponentQuote {
+    internalName
+  }
+  ... on ComponentTextBlock {
+    internalName
+  }
+}
+    `;
+export const PageContentFieldsFragmentDoc = `
+    fragment PageContentFields on PagePageContent {
+  __typename
+  ... on ComponentProductTable {
+    internalName
+  }
+  ... on TopicBusinessInfo {
+    internalName
+  }
+  ... on TopicProduct {
+    internalName
+  }
+}
+    `;
+export const PageExtraSectionItemFieldsFragmentDoc = `
+    fragment PageExtraSectionItemFields on PageExtraSectionItem {
+  __typename
+  ... on ComponentCta {
+    internalName
+  }
+  ... on ComponentDuplex {
+    internalName
+  }
+  ... on ComponentHeroBanner {
+    internalName
+  }
+  ... on ComponentInfoBlock {
+    internalName
+  }
+  ... on ComponentQuote {
+    internalName
+  }
+  ... on ComponentTextBlock {
+    internalName
+  }
+}
+    `;
 export const CtfPageFieldsFragmentDoc = `
     fragment CtfPageFields on Page {
   pageName
@@ -104,15 +198,33 @@ export const CtfPageFieldsFragmentDoc = `
   }
   topSectionCollection(limit: 20) {
     items {
-      ...ComponentReferenceFields
+      ... on Entry {
+        __typename
+        sys {
+          id
+        }
+      }
+      ...PageTopSectionFields
     }
   }
   pageContent {
-    ...ComponentReferenceFields
+    ... on Entry {
+      __typename
+      sys {
+        id
+      }
+    }
+    ...PageContentFields
   }
   extraSectionCollection(limit: 20) {
     items {
-      ...ComponentReferenceFields
+      ... on Entry {
+        __typename
+        sys {
+          id
+        }
+      }
+      ...PageExtraSectionItemFields
     }
   }
 }
@@ -132,7 +244,9 @@ export const CtfPageDocument = `
 }
     ${CtfPageFieldsFragmentDoc}
 ${AssetFieldsFragmentDoc}
-${ComponentReferenceFieldsFragmentDoc}`;
+${PageTopSectionFieldsFragmentDoc}
+${PageContentFieldsFragmentDoc}
+${PageExtraSectionItemFieldsFragmentDoc}`;
 export const useCtfPageQuery = <
       TData = CtfPageQuery,
       TError = unknown

--- a/src/components/features/ctf-components/ctf-page/ctf-page.graphql
+++ b/src/components/features/ctf-components/ctf-page/ctf-page.graphql
@@ -1,3 +1,61 @@
+fragment PageTopSectionFields on PageTopSectionItem {
+  __typename
+  ... on ComponentCta {
+    internalName
+  }
+  ... on ComponentDuplex {
+    internalName
+  }
+  ... on ComponentHeroBanner {
+    internalName
+  }
+  ... on ComponentInfoBlock {
+    internalName
+  }
+  ... on ComponentQuote {
+    internalName
+  }
+  ... on ComponentTextBlock {
+    internalName
+  }
+}
+
+fragment PageContentFields on PagePageContent {
+  __typename
+  ... on ComponentProductTable {
+    internalName
+  }
+  ... on TopicBusinessInfo {
+    internalName
+  }
+  ... on TopicProduct {
+    internalName
+  }
+}
+
+fragment PageExtraSectionItemFields on PageExtraSectionItem {
+  __typename
+  ... on ComponentCta {
+    internalName
+  }
+  ... on ComponentDuplex {
+    internalName
+  }
+  ... on ComponentHeroBanner {
+    internalName
+  }
+  ... on ComponentInfoBlock {
+    internalName
+  }
+  ... on ComponentQuote {
+    internalName
+  }
+  ... on ComponentTextBlock {
+    internalName
+  }
+}
+
+
 fragment CtfPageFields on Page {
   pageName
   internalName: pageName
@@ -13,15 +71,33 @@ fragment CtfPageFields on Page {
   }
   topSectionCollection(limit: 20) {
     items {
-      ...ComponentReferenceFields
+      ... on Entry {
+        __typename
+        sys {
+          id
+        }
+      }
+      ...PageTopSectionFields
     }
   }
   pageContent {
-    ...ComponentReferenceFields
+    ... on Entry {
+      __typename
+      sys {
+        id
+      }
+    }
+    ...PageContentFields
   }
   extraSectionCollection(limit: 20) {
     items {
-      ...ComponentReferenceFields
+      ... on Entry {
+        __typename
+        sys {
+          id
+        }
+      }
+      ...PageExtraSectionItemFields
     }
   }
 }

--- a/src/lib/__generated/graphql.types.ts
+++ b/src/lib/__generated/graphql.types.ts
@@ -3654,6 +3654,42 @@ export type CtfNavigationQueryVariables = Exact<{
 
 export type CtfNavigationQuery = { __typename?: 'Query', navigationMenuCollection?: { __typename?: 'NavigationMenuCollection', items: Array<{ __typename?: 'NavigationMenu', menuItemsCollection?: { __typename?: 'NavigationMenuMenuItemsCollection', items: Array<{ __typename?: 'MenuGroup', label?: string | null, link?: { __typename: 'Page', slug?: string | null, pageName?: string | null, sys: { __typename?: 'Sys', id: string }, pageContent?: { __typename: 'ComponentProductTable', sys: { __typename?: 'Sys', id: string } } | { __typename: 'TopicBusinessInfo', sys: { __typename?: 'Sys', id: string } } | { __typename: 'TopicProduct', sys: { __typename?: 'Sys', id: string } } | null } | null, children?: { __typename?: 'MenuGroupFeaturedPagesCollection', items: Array<{ __typename: 'Page', slug?: string | null, pageName?: string | null, sys: { __typename?: 'Sys', id: string }, pageContent?: { __typename: 'ComponentProductTable', sys: { __typename?: 'Sys', id: string } } | { __typename: 'TopicBusinessInfo', sys: { __typename?: 'Sys', id: string } } | { __typename: 'TopicProduct', sys: { __typename?: 'Sys', id: string } } | null } | null> } | null } | null> } | null } | null> } | null };
 
+type PageTopSectionFields_ComponentCta_Fragment = { __typename: 'ComponentCta', internalName?: string | null };
+
+type PageTopSectionFields_ComponentDuplex_Fragment = { __typename: 'ComponentDuplex', internalName?: string | null };
+
+type PageTopSectionFields_ComponentHeroBanner_Fragment = { __typename: 'ComponentHeroBanner', internalName?: string | null };
+
+type PageTopSectionFields_ComponentInfoBlock_Fragment = { __typename: 'ComponentInfoBlock', internalName?: string | null };
+
+type PageTopSectionFields_ComponentQuote_Fragment = { __typename: 'ComponentQuote', internalName?: string | null };
+
+type PageTopSectionFields_ComponentTextBlock_Fragment = { __typename: 'ComponentTextBlock', internalName?: string | null };
+
+export type PageTopSectionFieldsFragment = PageTopSectionFields_ComponentCta_Fragment | PageTopSectionFields_ComponentDuplex_Fragment | PageTopSectionFields_ComponentHeroBanner_Fragment | PageTopSectionFields_ComponentInfoBlock_Fragment | PageTopSectionFields_ComponentQuote_Fragment | PageTopSectionFields_ComponentTextBlock_Fragment;
+
+type PageContentFields_ComponentProductTable_Fragment = { __typename: 'ComponentProductTable', internalName?: string | null };
+
+type PageContentFields_TopicBusinessInfo_Fragment = { __typename: 'TopicBusinessInfo', internalName?: string | null };
+
+type PageContentFields_TopicProduct_Fragment = { __typename: 'TopicProduct', internalName?: string | null };
+
+export type PageContentFieldsFragment = PageContentFields_ComponentProductTable_Fragment | PageContentFields_TopicBusinessInfo_Fragment | PageContentFields_TopicProduct_Fragment;
+
+type PageExtraSectionItemFields_ComponentCta_Fragment = { __typename: 'ComponentCta', internalName?: string | null };
+
+type PageExtraSectionItemFields_ComponentDuplex_Fragment = { __typename: 'ComponentDuplex', internalName?: string | null };
+
+type PageExtraSectionItemFields_ComponentHeroBanner_Fragment = { __typename: 'ComponentHeroBanner', internalName?: string | null };
+
+type PageExtraSectionItemFields_ComponentInfoBlock_Fragment = { __typename: 'ComponentInfoBlock', internalName?: string | null };
+
+type PageExtraSectionItemFields_ComponentQuote_Fragment = { __typename: 'ComponentQuote', internalName?: string | null };
+
+type PageExtraSectionItemFields_ComponentTextBlock_Fragment = { __typename: 'ComponentTextBlock', internalName?: string | null };
+
+export type PageExtraSectionItemFieldsFragment = PageExtraSectionItemFields_ComponentCta_Fragment | PageExtraSectionItemFields_ComponentDuplex_Fragment | PageExtraSectionItemFields_ComponentHeroBanner_Fragment | PageExtraSectionItemFields_ComponentInfoBlock_Fragment | PageExtraSectionItemFields_ComponentQuote_Fragment | PageExtraSectionItemFields_ComponentTextBlock_Fragment;
+
 export type CtfPageFieldsFragment = { __typename?: 'Page', pageName?: string | null, slug?: string | null, internalName?: string | null, seo?: { __typename?: 'Seo', title?: string | null, description?: string | null, noIndex?: boolean | null, noFollow?: boolean | null, image?: { __typename: 'Asset', contentType?: string | null, title?: string | null, description?: string | null, width?: number | null, height?: number | null, url?: string | null, sys: { __typename?: 'Sys', id: string } } | null } | null, topSectionCollection?: { __typename?: 'PageTopSectionCollection', items: Array<{ __typename: 'ComponentCta', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentDuplex', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentHeroBanner', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentInfoBlock', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentQuote', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentTextBlock', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | null> } | null, pageContent?: { __typename: 'ComponentProductTable', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'TopicBusinessInfo', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'TopicProduct', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | null, extraSectionCollection?: { __typename?: 'PageExtraSectionCollection', items: Array<{ __typename: 'ComponentCta', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentDuplex', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentHeroBanner', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentInfoBlock', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentQuote', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | { __typename: 'ComponentTextBlock', internalName?: string | null, sys: { __typename?: 'Sys', id: string } } | null> } | null };
 
 export type CtfPageQueryVariables = Exact<{


### PR DESCRIPTION
## Purpose of PR

Several reference fields in the `ctf-page.graphql` were too generously querying for several reference components. These reference fields should only be reserved from references in rich content fields. The GQL fragments have been narrowed to prevent too complex queries that might lead to the codegen breaking in some cases.