### PR TITLE
fix: [] Update preview params guest space

### DIFF
--- a/src/components/features/settings/useExternalSpaceAndPreview.ts
+++ b/src/components/features/settings/useExternalSpaceAndPreview.ts
@@ -59,8 +59,6 @@ export const useExternalSpaceAndPreview = () => {
 
   const { domain, delivery_token, preview_token, space_id, preview } = router.query;
 
-  console.log({ domain, delivery_token, preview_token, space_id, preview });
-
   const previewActive = !!preview;
   const shouldUseSpaceCredsFromParams = !!delivery_token && !!preview_token && !!space_id;
 
@@ -77,10 +75,6 @@ export const useExternalSpaceAndPreview = () => {
   fetchConfig.endpoint = shouldUseSpaceCredsFromParams
     ? fetcherGraphqlEndpoint(space_id, domain as Domain)
     : fetcherGraphqlEndpoint(process.env.CONTENTFUL_SPACE_ID);
-
-  console.log({
-    fetchConfig,
-  });
 
   useEffect(() => {
     if (shouldUseSpaceCredsFromParams) {

--- a/src/components/features/settings/useExternalSpaceAndPreview.ts
+++ b/src/components/features/settings/useExternalSpaceAndPreview.ts
@@ -59,6 +59,8 @@ export const useExternalSpaceAndPreview = () => {
 
   const { domain, delivery_token, preview_token, space_id, preview } = router.query;
 
+  console.log({ domain, delivery_token, preview_token, space_id, preview });
+
   const previewActive = !!preview;
   const shouldUseSpaceCredsFromParams = !!delivery_token && !!preview_token && !!space_id;
 
@@ -70,9 +72,15 @@ export const useExternalSpaceAndPreview = () => {
   });
 
   fetchConfig.params.headers = fetchParams.headers;
+  fetchConfig.previewParams.headers = fetchParams.headers;
+
   fetchConfig.endpoint = shouldUseSpaceCredsFromParams
     ? fetcherGraphqlEndpoint(space_id, domain as Domain)
     : fetcherGraphqlEndpoint(process.env.CONTENTFUL_SPACE_ID);
+
+  console.log({
+    fetchConfig,
+  });
 
   useEffect(() => {
     if (shouldUseSpaceCredsFromParams) {


### PR DESCRIPTION
## Purpose of PR

Our live preview functionality relies on using the preview API which is passed through conditional logic in the `fetchConfig`. Our guest space functionality modified the `fetchConfig`, but failed to modify the `previewParams`. This is now fixed

