### PR TITLE
fix(security-headers): apply them also on the homepage

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -33,7 +33,7 @@ module.exports = async () => {
   return [
     {
       // Apply these headers to all routes in your application.
-      source: '/(.*)',
+      source: '/:path*',
       headers: securityHeaders,
     },
   ];


### PR DESCRIPTION
## Purpose of PR

Currently the security headers are not applied on the homepage.
Changing from `/(.*)` to `/:path*` would fix this, any concerns with doing it that way?