### PR TITLE
feat: [PLATO-718] support non production environments for live preview

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -13,7 +13,7 @@ const securityHeaders = [
   },
   {
     key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self' https://app.contentful.com`,
+    value: `frame-ancestors 'self' https://app.contentful.com http://localhost:3001`,
   },
   {
     key: 'X-Content-Type-Options',


### PR DESCRIPTION
## Purpose of PR

Add localhost to the Content Security Policy so that the live preview works for non production environments.

Ticket: https://contentful.atlassian.net/browse/PLATO-718

### Before
![image](https://github.com/contentful/template-marketing-webapp-nextjs/assets/8332893/09e163a2-5d15-4689-91f2-b9d61554bede)


### After
![image](https://github.com/contentful/template-marketing-webapp-nextjs/assets/8332893/92c68a75-79d9-47dc-987a-b66d8677f79c)



