### PR TITLE
fix: [PLATO-842] Add eu domain to images optimization and CSP

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -13,7 +13,7 @@ const securityHeaders = [
   },
   {
     key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self' https://app.contentful.com https://app.flinkly.com https://app.quirely.com http://localhost:3001`,
+    value: `frame-ancestors 'self' https://app.contentful.com https://app.flinkly.com https://app.quirely.com http://localhost:3001 https://app.eu.contentful.com`,
   },
   {
     key: 'X-Content-Type-Options',

--- a/next.config.js
+++ b/next.config.js
@@ -62,7 +62,7 @@ const moduleExports = withPlugins(plugins, {
    */
   images: {
     deviceSizes: [320, 420, 768, 1024, 1200, 1600],
-    domains: ['images.ctfassets.net', 'images.flinkly.com', 'images.quirely.com'],
+    domains: ['images.ctfassets.net', 'images.flinkly.com', 'images.quirely.com','images.eu.ctfassets.net'],
     path: '/_next/image',
     loader: 'default',
   },


### PR DESCRIPTION
What will change?

- added 'app.eu.contentful.com' to Content-Security-Policy so that it would allow the site to be embedded in an iframe from the eu-contentful.- 
added 'images.eu.ctfassets.net' to images - domains

ticket: https://contentful.atlassian.net/browse/PLATO-842