### PR TITLE
feat: add dependabot for managing live preview

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+registries:
+  npm-registry-registry-npmjs-org:
+    type: npm-registry
+    url: https://registry.npmjs.org
+    token: '${{secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN}}'
+
+updates:
+  - package-ecosystem: 'yarn'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '05:00'
+      timezone: UTC
+    commit-message:
+      prefix: build
+      include: scope
+    labels:
+      - 'dependencies'
+      - 'dependabot'
+    open-pull-requests-limit: 2
+    reviewers:
+      - 'contentful/team-tolkien'
+    registries:
+      - npm-registry-registry-npmjs-org
+    allow:
+      - dependency-name: '@contentful/live-preview'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ registries:
     token: '${{secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN}}'
 
 updates:
-  - package-ecosystem: 'yarn'
+  - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ registries:
     token: '${{secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN}}'
 
 updates:
+  # main branch
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -26,6 +27,7 @@ updates:
       - npm-registry-registry-npmjs-org
     allow:
       - dependency-name: '@contentful/live-preview'
+
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
@@ -36,3 +38,37 @@ updates:
     commit-message:
       prefix: build
       include: scope
+
+  # main-private branch
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '05:00'
+      timezone: UTC
+    commit-message:
+      prefix: build
+      include: scope
+    labels:
+      - 'dependencies'
+      - 'dependabot'
+    open-pull-requests-limit: 2
+    reviewers:
+      - 'contentful/team-tolkien'
+    registries:
+      - npm-registry-registry-npmjs-org
+    allow:
+      - dependency-name: '@contentful/live-preview'
+    target-branch: 'main-private'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '05:00'
+      timezone: UTC
+    open-pull-requests-limit: 15
+    commit-message:
+      prefix: build
+      include: scope
+    target-branch: 'main-private'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,7 @@ updates:
     labels:
       - 'dependencies'
       - 'dependabot'
+      - 'main-private'
     open-pull-requests-limit: 2
     reviewers:
       - 'contentful/team-tolkien'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,13 @@ updates:
       - npm-registry-registry-npmjs-org
     allow:
       - dependency-name: '@contentful/live-preview'
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '05:00'
+      timezone: UTC
+    open-pull-requests-limit: 15
+    commit-message:
+      prefix: build
+      include: scope

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,15 @@
+name: 'dependabot approve-and-request-merge'
+
+on: pull_request_target
+
+jobs:
+  worker:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: contentful/github-auto-merge@v1
+        with:
+          VAULT_URL: ${{ secrets.VAULT_URL }}


### PR DESCRIPTION
Adds dependabot for live-preview only to make managing versions across the starter templates more convenient