### PR TITLE
chore: remove npm policy

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -3,5 +3,4 @@ services:
   github-action:
     policies:
     - dependabot
-    - npm-read
     - packages-read


### PR DESCRIPTION
## Purpose of PR

Removes the NPM policy now that the migration to GitHub is done.