### PR TITLE
fix: add allowed origin domains for staging/preview live preview []

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,6 +16,16 @@ import colorfulTheme from '@src/theme';
 import contentfulConfig from 'contentful.config';
 import nextI18nConfig from 'next-i18next.config';
 
+const allowedOriginList = [
+  'https://app.contentful.com',
+  'https://app.eu.contentful.com',
+  'https://app.flinkly.com',
+  'https://app.eu.flinkly.com',
+  'https://app.quirely.com',
+  'https://app.eu.quirely.com',
+  'http://localhost:3001',
+];
+
 const LivePreviewProvider = ({ children }) => {
   const { previewActive, locale } = useContentfulContext();
 
@@ -24,6 +34,7 @@ const LivePreviewProvider = ({ children }) => {
       locale={locale}
       enableInspectorMode={previewActive}
       enableLiveUpdates={previewActive}
+      targetOrigin={allowedOriginList}
     >
       {children}
     </ContentfulLivePreviewProvider>


### PR DESCRIPTION
## Purpose of PR

**_What will change?_**

* Adds allowed origin domains for Live Preview on staging/preview environments

![live-preview](https://github.com/contentful/template-ecommerce-webapp-nextjs/assets/103024358/129f8d9f-49e8-45d4-91f2-2b8c4068ca50)

![live-preview-origin](https://github.com/contentful/template-ecommerce-webapp-nextjs/assets/103024358/096a8bac-9ecc-41ab-8fd3-ec2e7f09f885)