### PR TITLE
Update next-i18next.config.js

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -5,6 +5,6 @@ module.exports = {
     defaultLocale: 'en-US',
     locales: ['en-US', 'de-DE'],
     localeDetection: false,
-    localePath: path.resolve('./public/locales'),
   },
+  localePath: path.resolve('./public/locales'),
 };


### PR DESCRIPTION
according to the [the docs](https://github.com/i18next/next-i18next#6-advanced-configuration), the `localePath` option should be outside the `i18n` object. As is, this causes a warning when running `npm run dev`