### PR TITLE
fix: keep Contentful API tokens server-side [ACT-4857]

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -1,6 +1,6 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
-import { fetchConfig } from './src/lib/fetchConfig';
+import { fetchConfig } from './src/lib/serverFetchConfig';
 
 export const config: CodegenConfig = {
   overwrite: true,

--- a/contentful.config.js
+++ b/contentful.config.js
@@ -3,8 +3,6 @@ const url = process.env.NEXT_PUBLIC_BASE_URL;
 module.exports = {
   contentful: {
     space_id: process.env.CONTENTFUL_SPACE_ID || '',
-    cda_token: process.env.CONTENTFUL_ACCESS_TOKEN || '',
-    cpa_token: process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN || '',
   },
   meta: {
     title: 'Digital banking for the new generation | Colorful Coin',

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,10 @@ const { withPlugins } = nextComposePlugins.extend(() => ({}));
  */
 module.exports = withPlugins(plugins, {
   i18n,
+  /**
+   * add the environment variables you would like exposed to the client here
+   * documentation: https://nextjs.org/docs/api-reference/next.config.js/environment-variables
+   */
   env: {
     ENVIRONMENT_NAME: process.env.ENVIRONMENT_NAME,
   },

--- a/next.config.js
+++ b/next.config.js
@@ -17,15 +17,8 @@ const { withPlugins } = nextComposePlugins.extend(() => ({}));
  */
 module.exports = withPlugins(plugins, {
   i18n,
-  /**
-   * add the environment variables you would like exposed to the client here
-   * documentation: https://nextjs.org/docs/api-reference/next.config.js/environment-variables
-   */
   env: {
     ENVIRONMENT_NAME: process.env.ENVIRONMENT_NAME,
-    CONTENTFUL_SPACE_ID: process.env.CONTENTFUL_SPACE_ID,
-    CONTENTFUL_ACCESS_TOKEN: process.env.CONTENTFUL_ACCESS_TOKEN,
-    CONTENTFUL_PREVIEW_ACCESS_TOKEN: process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN,
   },
 
   /**

--- a/src/lib/contentfulQueries.ts
+++ b/src/lib/contentfulQueries.ts
@@ -1,0 +1,52 @@
+import { CtfBusinessInfoDocument } from '@src/components/features/ctf-components/ctf-business-info/__generated/business-info.generated';
+import { CtfCtaDocument } from '@src/components/features/ctf-components/ctf-cta/__generated/ctf-cta.generated';
+import { CtfDuplexDocument } from '@src/components/features/ctf-components/ctf-duplex/__generated/ctf-duplex.generated';
+import { CtfFooterDocument } from '@src/components/features/ctf-components/ctf-footer/__generated/ctf-footer.generated';
+import { CtfHeroBannerDocument } from '@src/components/features/ctf-components/ctf-hero-banner/__generated/ctf-hero-banner.generated';
+import { CtfInfoBlockDocument } from '@src/components/features/ctf-components/ctf-info-block/__generated/ctf-info-block.generated';
+import { CtfNavigationDocument } from '@src/components/features/ctf-components/ctf-navigation/__generated/ctf-navigation.generated';
+import { CtfPageDocument } from '@src/components/features/ctf-components/ctf-page/__generated/ctf-page.generated';
+import { CtfPersonDocument } from '@src/components/features/ctf-components/ctf-person/__generated/ctf-person.generated';
+import { CtfProductDocument } from '@src/components/features/ctf-components/ctf-product/__generated/ctf-product.generated';
+import { CtfProductFeatureDocument } from '@src/components/features/ctf-components/ctf-product-feature/__generated/ctf-product-feature.generated';
+import { CtfProductTableDocument } from '@src/components/features/ctf-components/ctf-product-table/__generated/ctf-product-table.generated';
+import { CtfQuoteDocument } from '@src/components/features/ctf-components/ctf-quote/__generated/ctf-quote.generated';
+import { CtfRichTextHyperlinkDocument } from '@src/components/features/ctf-components/ctf-richtext/__generated/ctf-richtext.generated';
+import { CtfTextBlockDocument } from '@src/components/features/ctf-components/ctf-text-block/__generated/ctf-text-block.generated';
+
+export function getContentfulQuery(operationName: string) {
+  switch (operationName) {
+    case 'CtfBusinessInfo':
+      return CtfBusinessInfoDocument;
+    case 'CtfCta':
+      return CtfCtaDocument;
+    case 'CtfDuplex':
+      return CtfDuplexDocument;
+    case 'CtfFooter':
+      return CtfFooterDocument;
+    case 'CtfHeroBanner':
+      return CtfHeroBannerDocument;
+    case 'CtfInfoBlock':
+      return CtfInfoBlockDocument;
+    case 'CtfNavigation':
+      return CtfNavigationDocument;
+    case 'CtfPage':
+      return CtfPageDocument;
+    case 'CtfPerson':
+      return CtfPersonDocument;
+    case 'CtfProduct':
+      return CtfProductDocument;
+    case 'CtfProductFeature':
+      return CtfProductFeatureDocument;
+    case 'CtfProductTable':
+      return CtfProductTableDocument;
+    case 'CtfQuote':
+      return CtfQuoteDocument;
+    case 'CtfRichTextHyperlink':
+      return CtfRichTextHyperlinkDocument;
+    case 'CtfTextBlock':
+      return CtfTextBlockDocument;
+    default:
+      return undefined;
+  }
+}

--- a/src/lib/fetchConfig.ts
+++ b/src/lib/fetchConfig.ts
@@ -4,6 +4,7 @@ export function customFetcher<TData, TVariables extends { preview?: boolean | nu
   options?: RequestInit['headers'],
 ) {
   return async (): Promise<TData> => {
+    const operationName = query.match(/\b(?:query|mutation|subscription)\s+([_A-Za-z][_0-9A-Za-z]*)/)?.[1];
     const headers = new Headers(options);
     headers.set('Content-Type', 'application/json');
 
@@ -13,7 +14,7 @@ export function customFetcher<TData, TVariables extends { preview?: boolean | nu
         : await fetch('/api/contentful', {
             method: 'POST',
             headers,
-            body: JSON.stringify({ query, variables }),
+            body: JSON.stringify({ operationName, variables }),
           });
 
     const json = await res.json();

--- a/src/lib/fetchConfig.ts
+++ b/src/lib/fetchConfig.ts
@@ -4,23 +4,32 @@ export function customFetcher<TData, TVariables extends { preview?: boolean | nu
   options?: RequestInit['headers'],
 ) {
   return async (): Promise<TData> => {
-    const operationName = query.match(/\b(?:query|mutation|subscription)\s+([_A-Za-z][_0-9A-Za-z]*)/)?.[1];
-    const headers = new Headers(options);
-    headers.set('Content-Type', 'application/json');
+    let res: Response;
 
-    const res =
-      typeof window === 'undefined'
-        ? await (await import('./serverFetchConfig')).fetchContentful(query, variables, options)
-        : await fetch('/api/contentful', {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({ operationName, variables }),
-          });
+    if (typeof window === 'undefined') {
+      const { fetchContentful } = await import('./serverFetchConfig');
+
+      res = await fetchContentful(query, variables, options);
+    } else {
+      const operationName = query.match(
+        /\b(?:query|mutation|subscription)\s+([_A-Za-z][_0-9A-Za-z]*)/,
+      )?.[1];
+      const headers = new Headers(options);
+      headers.set('Content-Type', 'application/json');
+
+      res = await fetch('/api/contentful', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ operationName, variables }),
+      });
+    }
 
     const json = await res.json();
 
     if (!res.ok) {
-      throw new Error(json.error || json.errors?.[0]?.message || `Contentful request failed (${res.status})`);
+      throw new Error(
+        json.error || json.errors?.[0]?.message || `Contentful request failed (${res.status})`,
+      );
     }
 
     if (json.errors) {

--- a/src/lib/fetchConfig.ts
+++ b/src/lib/fetchConfig.ts
@@ -4,16 +4,23 @@ export function customFetcher<TData, TVariables extends { preview?: boolean | nu
   options?: RequestInit['headers'],
 ) {
   return async (): Promise<TData> => {
+    const headers = new Headers(options);
+    headers.set('Content-Type', 'application/json');
+
     const res =
       typeof window === 'undefined'
         ? await (await import('./serverFetchConfig')).fetchContentful(query, variables, options)
         : await fetch('/api/contentful', {
             method: 'POST',
-            ...options,
+            headers,
             body: JSON.stringify({ query, variables }),
           });
 
     const json = await res.json();
+
+    if (!res.ok) {
+      throw new Error(json.error || json.errors?.[0]?.message || `Contentful request failed (${res.status})`);
+    }
 
     if (json.errors) {
       const { message } = json.errors[0];

--- a/src/lib/fetchConfig.ts
+++ b/src/lib/fetchConfig.ts
@@ -1,33 +1,17 @@
-export const fetchConfig = {
-  endpoint: `https://graphql.contentful.com/content/v1/spaces/${String(
-    process.env.CONTENTFUL_SPACE_ID,
-  )}`,
-  params: {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.CONTENTFUL_ACCESS_TOKEN}`,
-    },
-  },
-  previewParams: {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN}`,
-    },
-  },
-};
-
 export function customFetcher<TData, TVariables extends { preview?: boolean | null }>(
   query: string,
   variables?: TVariables,
   options?: RequestInit['headers'],
 ) {
   return async (): Promise<TData> => {
-    const res = await fetch(fetchConfig.endpoint as string, {
-      method: 'POST',
-      ...options,
-      ...(variables?.preview ? fetchConfig.previewParams : fetchConfig.params),
-      body: JSON.stringify({ query, variables }),
-    });
+    const res =
+      typeof window === 'undefined'
+        ? await (await import('./serverFetchConfig')).fetchContentful(query, variables, options)
+        : await fetch('/api/contentful', {
+            method: 'POST',
+            ...options,
+            body: JSON.stringify({ query, variables }),
+          });
 
     const json = await res.json();
 

--- a/src/lib/serverFetchConfig.ts
+++ b/src/lib/serverFetchConfig.ts
@@ -1,11 +1,16 @@
+const serverContentfulConfig = {
+  endpoint: `https://graphql.contentful.com/content/v1/spaces/${String(process.env.CONTENTFUL_SPACE_ID)}`,
+  spaceId: process.env.CONTENTFUL_SPACE_ID,
+  accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
+  previewAccessToken: process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN,
+};
+
 export const fetchConfig = {
-  endpoint: `https://graphql.contentful.com/content/v1/spaces/${String(
-    process.env.CONTENTFUL_SPACE_ID,
-  )}`,
+  endpoint: serverContentfulConfig.endpoint,
   params: {
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.CONTENTFUL_ACCESS_TOKEN}`,
+      Authorization: `Bearer ${serverContentfulConfig.accessToken}`,
     },
   },
 };
@@ -15,12 +20,11 @@ export function fetchContentful(
   variables?: { preview?: boolean | null },
   options?: RequestInit['headers'],
 ) {
-  const spaceId = process.env.CONTENTFUL_SPACE_ID;
   const token = variables?.preview
-    ? process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN
-    : process.env.CONTENTFUL_ACCESS_TOKEN;
+    ? serverContentfulConfig.previewAccessToken
+    : serverContentfulConfig.accessToken;
 
-  if (!spaceId || !token) {
+  if (!serverContentfulConfig.spaceId || !token) {
     throw new Error('Contentful is not configured');
   }
 
@@ -28,7 +32,7 @@ export function fetchContentful(
   headers.set('Content-Type', 'application/json');
   headers.set('Authorization', `Bearer ${token}`);
 
-  return fetch(`https://graphql.contentful.com/content/v1/spaces/${spaceId}`, {
+  return fetch(serverContentfulConfig.endpoint, {
     method: 'POST',
     headers,
     body: JSON.stringify({ query, variables }),

--- a/src/lib/serverFetchConfig.ts
+++ b/src/lib/serverFetchConfig.ts
@@ -1,0 +1,36 @@
+export const fetchConfig = {
+  endpoint: `https://graphql.contentful.com/content/v1/spaces/${String(
+    process.env.CONTENTFUL_SPACE_ID,
+  )}`,
+  params: {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.CONTENTFUL_ACCESS_TOKEN}`,
+    },
+  },
+};
+
+export function fetchContentful(
+  query: string,
+  variables?: { preview?: boolean | null },
+  options?: RequestInit['headers'],
+) {
+  const spaceId = process.env.CONTENTFUL_SPACE_ID;
+  const token = variables?.preview
+    ? process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN
+    : process.env.CONTENTFUL_ACCESS_TOKEN;
+
+  if (!spaceId || !token) {
+    throw new Error('Contentful is not configured');
+  }
+
+  return fetch(`https://graphql.contentful.com/content/v1/spaces/${spaceId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      ...options,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+}

--- a/src/lib/serverFetchConfig.ts
+++ b/src/lib/serverFetchConfig.ts
@@ -24,13 +24,13 @@ export function fetchContentful(
     throw new Error('Contentful is not configured');
   }
 
+  const headers = new Headers(options);
+  headers.set('Content-Type', 'application/json');
+  headers.set('Authorization', `Bearer ${token}`);
+
   return fetch(`https://graphql.contentful.com/content/v1/spaces/${spaceId}`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-      ...options,
-    },
+    headers,
     body: JSON.stringify({ query, variables }),
   });
 }

--- a/src/pages/api/contentful.ts
+++ b/src/pages/api/contentful.ts
@@ -16,18 +16,27 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  if (!req.body || typeof req.body !== 'object') {
+    return res.status(400).json({ error: 'Request body must be JSON' });
+  }
+
   const { query, variables } = req.body as {
     query?: string;
-    variables?: { preview?: boolean | null };
+    variables?: Record<string, unknown> & { preview?: boolean | null };
   };
 
-  if (!query) {
+  if (typeof query !== 'string' || !query.trim()) {
     return res.status(400).json({ error: 'Query is required' });
   }
 
-  const response = await fetchContentful(query, variables);
+  try {
+    const response = await fetchContentful(query, variables);
 
-  const body = (await response.json()) as ContentfulResponse;
+    const body = (await response.json()) as ContentfulResponse;
 
-  return res.status(response.status).json(body);
+    return res.status(response.status).json(body);
+  } catch (error) {
+    console.error('Contentful proxy request failed', error);
+    return res.status(502).json({ error: 'Contentful request failed' });
+  }
 }

--- a/src/pages/api/contentful.ts
+++ b/src/pages/api/contentful.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+import { getContentfulQuery } from '@src/lib/contentfulQueries';
 import { fetchContentful } from '@src/lib/serverFetchConfig';
 
 type ContentfulResponse = {
@@ -20,13 +21,19 @@ export default async function handler(
     return res.status(400).json({ error: 'Request body must be JSON' });
   }
 
-  const { query, variables } = req.body as {
-    query?: string;
+  const { operationName, variables } = req.body as {
+    operationName?: string;
     variables?: Record<string, unknown> & { preview?: boolean | null };
   };
 
-  if (typeof query !== 'string' || !query.trim()) {
-    return res.status(400).json({ error: 'Query is required' });
+  if (typeof operationName !== 'string' || !operationName.trim()) {
+    return res.status(400).json({ error: 'Operation name is required' });
+  }
+
+  const query = getContentfulQuery(operationName);
+
+  if (!query) {
+    return res.status(400).json({ error: 'Unknown operation' });
   }
 
   try {

--- a/src/pages/api/contentful.ts
+++ b/src/pages/api/contentful.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { fetchContentful } from '@src/lib/serverFetchConfig';
+
+type ContentfulResponse = {
+  data?: unknown;
+  errors?: unknown;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ContentfulResponse | { error: string }>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { query, variables } = req.body as {
+    query?: string;
+    variables?: { preview?: boolean | null };
+  };
+
+  if (!query) {
+    return res.status(400).json({ error: 'Query is required' });
+  }
+
+  const response = await fetchContentful(query, variables);
+
+  const body = (await response.json()) as ContentfulResponse;
+
+  return res.status(response.status).json(body);
+}


### PR DESCRIPTION
## Purpose of PR

Fixes [ACT-4857](https://contentful.atlassian.net/browse/ACT-4857).

The marketing starter template exposed Contentful Delivery and Preview API tokens through client-bundled configuration. This PR keeps those tokens server-side and routes browser-side GraphQL requests through a same-origin Next.js API route.

## Deployment & Risks

- [ ] There is a migration necessary to make this work
- [ ] There is a dependent PR that needs to be deployed first
- [x] I have read the relevant `README.md` and security finding
- [ ] Tests are added/updated/not required
- [x] Tests/checks are passing locally
- [x] Usage notes are not required
- [x] Doesn't contain any sensitive information

Vercel preview deployment completed successfully. The current Vercel production project is `contentful-apps/template-marketing-webapp-nextjs`, using Contentful space `vw5be3ki3sdd`.

Credential rotation and replacement of the Vercel Delivery/Preview variables remain follow-ups before closing ACT-4857.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run build` with dummy credentials
- Client bundle scan: no Contentful token names or values
- API route smoke checks: GET returns 405; POST without an operation name returns 400; unknown operations return 400
- Browser-shaped JSON POST for a known operation reaches Contentful and passes through its upstream 401 response with dummy credentials

## Security

The Contentful tokens are no longer present in `next.config.js` or the client-imported `contentful.config.js`. Server-side requests use `src/lib/serverFetchConfig.ts`. Browser-side requests use `/api/contentful`, which accepts only an allowlisted operation name and variables, reconstructs the static query server-side, and never returns credentials. Generated query text remains visible in client code because it is not secret; it is never accepted from the browser or used as the server query source.


[ACT-4857]: https://contentful.atlassian.net/browse/ACT-4857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ